### PR TITLE
Fix obtention of rx_bitrate and tx_bitrate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ fn main() -> Result<(), Box<dyn Error>> {
       // average signal : -61 dBm
       // rx packets : 148983
       // tx packets : 46335
-      // rx bitrate : 60 Mb/s
-      // tx bitrate : 140 Mb/s
+      // rx bitrate : 60.0 Mb/s
+      // tx bitrate : 140.0 Mb/s
       // tx retries : 12578
       // tx failed : 2
   }
@@ -107,8 +107,8 @@ fn main() -> Result<(), Box<dyn Error>> {
       // average signal : -61 dBm
       // rx packets : 148983
       // tx packets : 46335
-      // rx bitrate : 60 Mb/s
-      // tx bitrate : 140 Mb/s
+      // rx bitrate : 60.0 Mb/s
+      // tx bitrate : 140.0 Mb/s
       // tx retries : 12578
       // tx failed : 2
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,8 +82,8 @@
 //!       // average signal : -61 dBm
 //!       // rx packets : 148983
 //!       // tx packets : 46335
-//!       // rx bitrate : 60 Mb/s
-//!       // tx bitrate : 140 Mb/s
+//!       // rx bitrate : 650.0 Mb/s
+//!       // tx bitrate : 866.7 Mb/s
 //!       // tx retries : 12578
 //!       // tx failed : 2
 //!   }


### PR DESCRIPTION
The obtention of the rx/tx bitrates was implemented incorrectly.

The obtention was searching for a type of
Nl80211StaInfo::StaInfoRxBytes, which is of the wrong enum type, and
effectively maps to Nl80211RateInfo::RateInfoMcs, when it should be
mapping to Nl80211StaInfo::RateInfoBitrate or
Nl80211StaInfo::RateInfoBitrate32.

The 32-bit bitrate was introduced almost 10 years ago, so I don't believe it's
necessary to account for the possibility of it not being there, like
`iw` does (see `parse_bitrate()` in `station.c`).